### PR TITLE
Add Whalebrew labels to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,7 @@ RUN cd dockercloud && \
     docker-cloud -v
 WORKDIR /root
 
+LABEL io.whalebrew.name docker-cloud
+LABEL io.whalebrew.config.volumes '["~/.docker:/root/.docker:ro"]'
+
 ENTRYPOINT ["docker-cloud"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM alpine
-MAINTAINER support@docker.com
 
 RUN apk --update add python py-pip
 COPY . /dockercloud


### PR DESCRIPTION
Allows image to be installed as a Docker image with Whalebrew: https://github.com/bfirsh/whalebrew

It'd work like this:

    $ whalebrew install dockercloud/cli

This is much better than using pip, and arguably for a Docker tool, using a Docker image is better than Homebrew. ;)